### PR TITLE
use package module instead of yum

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Ensure Samba-related packages are installed (RedHat).
-  yum: "name={{ item }} state=present"
+  package: "name={{ item }} state=present"
   with_items:
     - samba
     - samba-client


### PR DESCRIPTION
Hi,
this playbook works just fine on fedora if you use the package module instead of the yum module. Also yum is soon going away anyway so this will make the transition as smooth as possible as soon as centos adopts dnf over yum.
Greetings, Sascha