### PR TITLE
Clean up package install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,23 +2,10 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Ensure Samba-related packages are installed (RedHat).
-  package: "name={{ item }} state=present"
-  with_items:
-    - samba
-    - samba-client
-    - samba-common
-    - cifs-utils
-  when: ansible_os_family == 'RedHat'
-
-- name: Ensure Samba-related packages are installed (Debian).
-  apt: "name={{ item }} state=present"
-  with_items:
-    - samba
-    - samba-common
-    - python-glade2
-    - system-config-samba
-  when: ansible_os_family == 'Debian'
+- name: Ensure Samba-related packages are installed
+  package:
+    name: "{{ samba_packages }}"
+    state: present
 
 - name: Ensure Samba is running and set to start on boot.
   service: "name={{ samba_daemon }} state=started enabled=yes"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,8 @@
 ---
 samba_daemon: smbd
+
+samba_packages:
+  - samba
+  - samba-common
+  - python-glade2
+  - system-config-samba

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,8 @@
 ---
 samba_daemon: smb
+
+samba_packages:
+  - samba
+  - samba-client
+  - samba-common
+  - cifs-utils


### PR DESCRIPTION
As you already have variable files for each platform, it makes sense to use them to declare the packages lists.

This is similar to https://github.com/geerlingguy/ansible-role-samba/pull/8, but also uses the variable file for the package list on Red Hat platforms.