### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,6 @@
   with_items:
     - samba
     - samba-common
-    - python-glade2
     - system-config-samba
   when: ansible_os_family == 'Debian'
 


### PR DESCRIPTION
python-glade2 doesn't seem to be available on ubuntu 20.04.2

these are the packages i see:

```
samba - SMB/CIFS file, print, and login server for Unix
samba-common - common files used by both the Samba server and client
samba-common-bin - Samba common files used by both the server and the client
samba-dev - tools for extending Samba
samba-dsdb-modules - Samba Directory Services Database
samba-libs - Samba core libraries
samba-vfs-modules - Samba Virtual FileSystem plugins
smbclient - command-line SMB/CIFS clients for Unix
```